### PR TITLE
Stellaris parser update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 coverage/
 lib/jomini.js
+.idea

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,7 @@ var jscs = require('gulp-jscs');
 var mocha = require('gulp-mocha');
 var jshint = require('gulp-jshint');
 var istanbul = require('gulp-istanbul');
-var jisonCli = require('gulp-jison-cli');
+var jisonCli = require('gulp-jison');
 
 gulp.task('test', ['jison'], function(cb) {
   gulp.src(['lib/*.js', '!lib/jomini.js'])

--- a/lib/jomini.jison
+++ b/lib/jomini.jison
@@ -17,7 +17,7 @@ var setProp = require('./setProp');
 "}"                   return '}'
 "="                   return '='
 \"[^\"]*\"         yytext = yytext.substr(1,yyleng-2); return 'QIDENTIFIER'
-[a-zA-Z0-9_\.]+          return 'IDENTIFIER'
+[a-zA-Z0-9_\.:]+          return 'IDENTIFIER'
 "#"[^\r\n]*((\r\n)|<<EOF>>)       /* skip comments */
 .                     return 'INVALID'
 <<EOF>>               return 'EOF'
@@ -46,6 +46,10 @@ PMemberList
 PMember 
     : IDENTIFIER '=' PValue
         {key = $1; value = $3;}
+	| QIDENTIFIER '=' PValue
+		{key = $1; value = $3;}
+	| '=' '=' PValue
+		{key = $1; value = $3;}
     | NUMBER '=' PValue
         {key = $1; value = $3;}
     | DATE '=' PValue

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "json3": "^3.3.2",
     "mocha": "^2.1.0",
     "zuul": "^1.17.0",
-    "gulp-jison-cli": "^0.1.4"
+    "gulp-jison": "^1.2.0"
   },
   "homepage": "https://github.com/nickbabcock/jomini",
   "keywords": [

--- a/test/parse.js
+++ b/test/parse.js
@@ -295,4 +295,16 @@ describe('parse', function() {
     expect(parse('foo={bar=val} {} { } me=you')).to.deep.
         equal({foo: {bar: 'val'}, me: 'you'});
   });
+
+  it('should handle strings as identifiers', function() {
+    expect(parse('"foo"="bar"')).to.deep.equal({'foo': 'bar'});
+  });
+
+  it('should handle = as identifier', function() {
+    expect(parse('=="bar"')).to.deep.equal({'=': 'bar'});
+  });
+
+  it('should handle values with colon sign', function() {
+    expect(parse('foo=bar:foo')).to.deep.equal({'foo': 'bar:foo'});
+  });
 });


### PR DESCRIPTION
Hi,

When trying to parse new Paradox production on Clausewitz engine - Stellaris I encountered a few differences in parsing ".sav" files. Notably:
````
==<value>
"<string>"=<value>
<key>=<string>:<string>
````
So using current version of jomini throwed errors at me. So I fixed them, but I'm not sure how I am supposed to interpret them - maybe I did something wrong. Anyway, Stellaris save game files parses now without errors. :)

What I also did was replacing the `gulp-jison-cli` with `gulp-jison`, becouse of errors I get when trying to run `gulp` command. It says:
````
Error: Cannot find module './node_modules/jison/lib/cli'
````
Migrating to `gulp-jison` fixed it.

Thanks for writting this parser!