### PR TITLE
Fix parse error on dashed identifiers

### DIFF
--- a/lib/jomini.jison
+++ b/lib/jomini.jison
@@ -19,7 +19,7 @@ var setProp = require('./setProp');
 "rgb"                 return 'rgb'
 "="                   return '='
 \"[^\"]*\"         yytext = yytext.substr(1,yyleng-2); return 'QIDENTIFIER'
-[a-zA-Z0-9_\.:@]+          return 'IDENTIFIER'
+[a-zA-Z0-9\-_\.:@]+   return 'IDENTIFIER'
 "#"[^\r\n]*((\r\n)|<<EOF>>)       /* skip comments */
 .                     return 'INVALID'
 <<EOF>>               return 'EOF'

--- a/test/parse.js
+++ b/test/parse.js
@@ -304,6 +304,10 @@ describe('parse', function() {
     expect(parse('=="bar"')).to.deep.equal({'=': 'bar'});
   });
 
+  it('should handle dashed identifiers', function() {
+    expect(parse('dashed-identifier=bar')).to.deep.equal({'dashed-identifier': 'bar'});
+  });
+
   it('should handle values with colon sign', function() {
     expect(parse('foo=bar:foo')).to.deep.equal({'foo': 'bar:foo'});
   });


### PR DESCRIPTION
Discovered a dashed identifier in one of my saves ("planetarydiversity-nw") and this seems to fix the parse error quite handily.