### PR TITLE
Support additional operators

### DIFF
--- a/lib/jomini.jison
+++ b/lib/jomini.jison
@@ -17,7 +17,11 @@ var setProp = require('./setProp');
 "}"                   return '}'
 "hsv"                 return 'hsv'
 "rgb"                 return 'rgb'
+"<="                  return '<='
+">="                  return '>='
 "="                   return '='
+"<"                   return '<'
+">"                   return '>'
 \"[^\"]*\"         yytext = yytext.substr(1,yyleng-2); return 'QIDENTIFIER'
 [a-zA-Z0-9\-_\.:@]+   return 'IDENTIFIER'
 "#"[^\r\n]*((\r\n)|<<EOF>>)       /* skip comments */
@@ -62,6 +66,26 @@ PMember
         {key = $1; value = {};}
     | '{' '}'
         {key = undefined;}
+
+    | IDENTIFIER '<' PValue
+        {key = $1; value = {'LESS_THAN': $3};}
+    | QIDENTIFIER '<' PValue
+        {key = $1; value = {'LESS_THAN': $3};}
+
+    | IDENTIFIER '<=' PValue
+        {key = $1; value = {'LESS_THAN_EQUAL': $3};}
+    | QIDENTIFIER '<=' PValue
+        {key = $1; value = {'LESS_THAN_EQUAL': $3};}
+
+    | IDENTIFIER '>' PValue
+        {key = $1; value = {'GREATER_THAN': $3};}
+    | QIDENTIFIER '>' PValue
+        {key = $1; value = {'GREATER_THAN': $3};}
+
+    | IDENTIFIER '>=' PValue
+        {key = $1; value = {'GREATER_THAN_EQUAL': $3};}
+    | QIDENTIFIER '>=' PValue
+        {key = $1; value = {'GREATER_THAN_EQUAL': $3};}
     ;
 
 PList

--- a/test/parse.js
+++ b/test/parse.js
@@ -323,4 +323,36 @@ describe('parse', function() {
   it('should handle rgb', function() {
       expect(parse('color = rgb { 100 200 150 }')).to.deep.equal({'color': { r: 100, g: 200, b: 150 }});
   });
+
+  it('should handle less than operator', function() {
+      expect(parse("has_level < 2")).to.deep.equal({'has_level': { 'LESS_THAN': 2 }});
+  });
+
+  it('should handle less than operator quotes', function() {
+      expect(parse("\"has_level2\" < 2")).to.deep.equal({'has_level2': { 'LESS_THAN': 2 }});
+  });
+
+  it('should handle less than or equal to operator', function() {
+      expect(parse("has_level <= 2")).to.deep.equal({'has_level': { 'LESS_THAN_EQUAL': 2 }});
+  });
+
+  it('should handle less than or equal to operator quotes', function() {
+      expect(parse("\"has_level2\" <= 2")).to.deep.equal({'has_level2': { 'LESS_THAN_EQUAL': 2 }});
+  });
+
+  it('should handle greater than operator', function() {
+      expect(parse("has_level > 2")).to.deep.equal({'has_level': { 'GREATER_THAN': 2 }});
+  });
+
+  it('should handle greater than operator quotes', function() {
+      expect(parse("\"has_level2\" > 2")).to.deep.equal({'has_level2': { 'GREATER_THAN': 2 }});
+  });
+
+  it('should handle greater than or equal to operator', function() {
+      expect(parse("has_level >= 2")).to.deep.equal({'has_level': { 'GREATER_THAN_EQUAL': 2 }});
+  });
+
+  it('should handle greater than or equal to operator quotes', function() {
+      expect(parse("\"has_level2\" >= 2")).to.deep.equal({'has_level2': { 'GREATER_THAN_EQUAL': 2 }});
+  });
 });


### PR DESCRIPTION
```
has_level >= 2
```

Is now parseable. The output is 

```js
{'has_level': { 'GREATER_THAN_EQUAL': 2 }}
```

Other newly supported operators:

- `>`
- `<`
- `<=`

Closes #9 