### PR TITLE
allow escaped double quotes (closes #11)

### DIFF
--- a/lib/jomini.jison
+++ b/lib/jomini.jison
@@ -23,7 +23,7 @@ var setProp = require('./setProp');
 "<"                   return '<'
 ">"                   return '>'
 "\\\""                return '"'
-\"[^\"\\]*(?:\\.[^\"\\]*)*\" yytext = yytext.substr(1,yyleng-2); return 'QIDENTIFIER'
+\"[^\"\\]*(?:\\.[^\"\\]*)*\" yytext = yytext.substr(1,yyleng-2).replace(/\\\"/g, '"'); return 'QIDENTIFIER'
 [a-zA-Z0-9\-_\.:@]+   return 'IDENTIFIER'
 "#"[^\r\n]*((\r\n)|<<EOF>>)       /* skip comments */
 .                     return 'INVALID'

--- a/lib/jomini.jison
+++ b/lib/jomini.jison
@@ -22,7 +22,8 @@ var setProp = require('./setProp');
 "="                   return '='
 "<"                   return '<'
 ">"                   return '>'
-\"[^\"]*\"         yytext = yytext.substr(1,yyleng-2); return 'QIDENTIFIER'
+"\\\""                return '"'
+\"[^\"\\]*(?:\\.[^\"\\]*)*\" yytext = yytext.substr(1,yyleng-2); return 'QIDENTIFIER'
 [a-zA-Z0-9\-_\.:@]+   return 'IDENTIFIER'
 "#"[^\r\n]*((\r\n)|<<EOF>>)       /* skip comments */
 .                     return 'INVALID'

--- a/test/parse.js
+++ b/test/parse.js
@@ -358,6 +358,6 @@ describe('parse', function () {
     expect(parse("\"has_level2\" >= 2")).to.deep.equal({ 'has_level2': { 'GREATER_THAN_EQUAL': 2 } });
   });
   it('should handle escaped double quotes', function () {
-    expect(parse("desc=\"\\\"Captain\\\"\"")).to.deep.equal({ 'desc': "\\\"Captain\\\"" });
+    expect(parse("desc=\"\\\"Captain\\\"\"")).to.deep.equal({ 'desc': "\"Captain\"" });
   });
 });

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,127 +1,127 @@
 var parse = require('../lib/jomini').parse;
 var expect = require('chai').expect;
 
-describe('parse', function() {
-  it('should handle the simple parse case', function() {
-    expect(parse('foo=bar')).to.deep.equal({foo: 'bar'});
+describe('parse', function () {
+  it('should handle the simple parse case', function () {
+    expect(parse('foo=bar')).to.deep.equal({ foo: 'bar' });
   });
 
-  it('should handle the simple header case', function() {
-    expect(parse('EU4txt\nfoo=bar')).to.deep.equal({foo: 'bar'});
+  it('should handle the simple header case', function () {
+    expect(parse('EU4txt\nfoo=bar')).to.deep.equal({ foo: 'bar' });
   });
 
-  it('should handle empty quoted strings', function() {
-    expect(parse('foo=""')).to.deep.equal({foo: ''});
+  it('should handle empty quoted strings', function () {
+    expect(parse('foo=""')).to.deep.equal({ foo: '' });
   });
 
-  it('should handle whitespace', function() {
-    expect(parse('\tfoo = bar ')).to.deep.equal({'foo':'bar'});
+  it('should handle whitespace', function () {
+    expect(parse('\tfoo = bar ')).to.deep.equal({ 'foo': 'bar' });
   });
 
-  it('should handle the simple quoted case', function() {
-    expect(parse('foo="bar"')).to.deep.equal({'foo':'bar'});
+  it('should handle the simple quoted case', function () {
+    expect(parse('foo="bar"')).to.deep.equal({ 'foo': 'bar' });
   });
 
-  it('should handle string list accumulation', function() {
-    expect(parse('foo=bar\nfoo=qux')).to.deep.equal({'foo':['bar', 'qux']});
+  it('should handle string list accumulation', function () {
+    expect(parse('foo=bar\nfoo=qux')).to.deep.equal({ 'foo': ['bar', 'qux'] });
   });
 
-  it('should handle string list accumulation long', function() {
+  it('should handle string list accumulation long', function () {
     expect(parse('foo=bar\nfoo=qux\nfoo=baz')).to.deep.
-        equal({'foo':['bar', 'qux', 'baz']});
+      equal({ 'foo': ['bar', 'qux', 'baz'] });
   });
 
-  it('should handle quoted string list accumulation', function() {
+  it('should handle quoted string list accumulation', function () {
     expect(parse('foo="bar"\nfoo="qux"')).to.deep.
-        equal({'foo':['bar', 'qux']});
+      equal({ 'foo': ['bar', 'qux'] });
   });
 
-  it('should handle boolen', function() {
-    expect(parse('foo=yes')).to.deep.equal({'foo': true});
+  it('should handle boolen', function () {
+    expect(parse('foo=yes')).to.deep.equal({ 'foo': true });
   });
 
-  it('should handle boolen list', function() {
-    expect(parse('foo={yes no}')).to.deep.equal({'foo': [true, false]});
+  it('should handle boolen list', function () {
+    expect(parse('foo={yes no}')).to.deep.equal({ 'foo': [true, false] });
   });
 
-  it('should handle whole numbers', function() {
-    expect(parse('foo=1')).to.deep.equal({'foo': 1});
+  it('should handle whole numbers', function () {
+    expect(parse('foo=1')).to.deep.equal({ 'foo': 1 });
   });
 
-  it('should handle zero', function() {
-    expect(parse('foo=0')).to.deep.equal({'foo': 0});
+  it('should handle zero', function () {
+    expect(parse('foo=0')).to.deep.equal({ 'foo': 0 });
   });
 
-  it('should handle negative whole numbers', function() {
-    expect(parse('foo=-1')).to.deep.equal({'foo': -1});
+  it('should handle negative whole numbers', function () {
+    expect(parse('foo=-1')).to.deep.equal({ 'foo': -1 });
   });
 
-  it('should handle decimal number', function() {
-    expect(parse('foo=1.23')).to.deep.equal({'foo': 1.23});
+  it('should handle decimal number', function () {
+    expect(parse('foo=1.23')).to.deep.equal({ 'foo': 1.23 });
   });
 
-  it('should handle negative decimal number', function() {
-    expect(parse('foo=-1.23')).to.deep.equal({'foo': -1.23});
+  it('should handle negative decimal number', function () {
+    expect(parse('foo=-1.23')).to.deep.equal({ 'foo': -1.23 });
   });
 
-  it('should handle number list accumulation', function() {
-    expect(parse('foo=1\nfoo=-1.23')).to.deep.equal({'foo':[1, -1.23]});
+  it('should handle number list accumulation', function () {
+    expect(parse('foo=1\nfoo=-1.23')).to.deep.equal({ 'foo': [1, -1.23] });
   });
 
-  it('should handle dates', function() {
+  it('should handle dates', function () {
     expect(parse('date=1821.1.1')).to.deep.
-        equal({'date': new Date(Date.UTC(1821, 0, 1))});
+      equal({ 'date': new Date(Date.UTC(1821, 0, 1)) });
   });
 
   /*it('should deceptive dates', function() {
     expect(parse('date=1821.a.1')).to.deep.equal({date': '1821.a.1'});
   });*/
 
-  it('should handle quoted dates', function() {
+  it('should handle quoted dates', function () {
     expect(parse('date="1821.1.1"')).to.deep.
-        equal({'date': new Date(Date.UTC(1821, 0, 1))});
+      equal({ 'date': new Date(Date.UTC(1821, 0, 1)) });
   });
 
-  it('should handle accumulated dates', function() {
+  it('should handle accumulated dates', function () {
     expect(parse('date="1821.1.1"\ndate=1821.2.1')).to.deep.equal(
-      {'date':[new Date(Date.UTC(1821, 0, 1)), new Date(Date.UTC(1821, 1, 1))]}
+      { 'date': [new Date(Date.UTC(1821, 0, 1)), new Date(Date.UTC(1821, 1, 1))] }
     );
   });
 
-  it('should handle numbers as identifiers', function() {
-    expect(parse('158=10')).to.deep.equal({'158': 10});
+  it('should handle numbers as identifiers', function () {
+    expect(parse('158=10')).to.deep.equal({ '158': 10 });
   });
 
-  it('should handle periods in identifiers', function() {
-    expect(parse('flavor_tur.8=yes')).to.deep.equal({'flavor_tur.8': true});
+  it('should handle periods in identifiers', function () {
+    expect(parse('flavor_tur.8=yes')).to.deep.equal({ 'flavor_tur.8': true });
   });
 
-  it('should handle empty objects for dates', function() {
-    expect(parse('1920.1.1={}')).to.deep.equal({'1920.1.1': {}});
+  it('should handle empty objects for dates', function () {
+    expect(parse('1920.1.1={}')).to.deep.equal({ '1920.1.1': {} });
   });
 
-  it('should handle consecutive strings', function() {
-    expect(parse('foo = { bar baz }')).to.deep.equal({'foo': ['bar', 'baz']});
+  it('should handle consecutive strings', function () {
+    expect(parse('foo = { bar baz }')).to.deep.equal({ 'foo': ['bar', 'baz'] });
   });
 
-  it('should handle consecutive strings no space', function() {
-    expect(parse('foo={bar baz}')).to.deep.equal({'foo': ['bar', 'baz']});
+  it('should handle consecutive strings no space', function () {
+    expect(parse('foo={bar baz}')).to.deep.equal({ 'foo': ['bar', 'baz'] });
   });
 
-  it('should handle consecutive quoted strings', function() {
+  it('should handle consecutive quoted strings', function () {
     expect(parse('foo = { "bar" "baz" }')).to.deep.
-        equal({'foo': ['bar', 'baz']});
+      equal({ 'foo': ['bar', 'baz'] });
   });
 
-  it('should handle empty object', function() {
-    expect(parse('foo = {}')).to.deep.equal({'foo': {}});
+  it('should handle empty object', function () {
+    expect(parse('foo = {}')).to.deep.equal({ 'foo': {} });
   });
 
-  it('should handle space empty object', function() {
-    expect(parse('foo = { }')).to.deep.equal({'foo': {}});
+  it('should handle space empty object', function () {
+    expect(parse('foo = { }')).to.deep.equal({ 'foo': {} });
   });
 
-  it('should handle the object after empty object', function() {
+  it('should handle the object after empty object', function () {
     var obj = {
       foo: {},
       catholic: {
@@ -132,7 +132,7 @@ describe('parse', function() {
     expect(parse('foo={} catholic={defender="me"}')).to.deep.equal(obj);
   });
 
-  it('should handle the object after empty object nested', function() {
+  it('should handle the object after empty object nested', function () {
     var obj = {
       religion: {
         foo: {},
@@ -143,15 +143,15 @@ describe('parse', function() {
     };
 
     expect(parse('religion={foo={} catholic={defender="me"}}')).to.deep.
-        equal(obj);
+      equal(obj);
   });
 
-  it('should ignore empty objects with no identifier at end', function() {
+  it('should ignore empty objects with no identifier at end', function () {
     expect(parse('foo={bar=val {}}  { } me=you')).to.deep.
-        equal({foo: {bar: 'val'}, me: 'you'});
+      equal({ foo: { bar: 'val' }, me: 'you' });
   });
 
-  it('should understand a list of objects', function() {
+  it('should understand a list of objects', function () {
     var str = 'attachments={ { id=258579 type=4713 } ' +
       ' { id=258722 type=4713 } }';
     var obj = {
@@ -167,18 +167,18 @@ describe('parse', function() {
     expect(parse(str)).to.deep.equal(obj);
   });
 
-  it('should parse minimal spacing for objects', function() {
+  it('should parse minimal spacing for objects', function () {
     var str = 'nation={ship={name="ship1"} ship={name="ship2"}}';
     var obj = {
       nation: {
-        ship: [{name: 'ship1'}, {name: 'ship2'}]
+        ship: [{ name: 'ship1' }, { name: 'ship2' }]
       }
     };
 
     expect(parse(str)).to.deep.equal(obj);
   });
 
-  it('should understand a simple EU4 header', function() {
+  it('should understand a simple EU4 header', function () {
     var str = 'date=1640.7.1\r\nplayer="FRA"\r\nsavegame_version=' +
       '\r\n{\r\n\tfirst=1\r\n\tsecond=9\r\n\tthird=2\r\n\tforth=0\r\n}';
     var obj = {
@@ -194,7 +194,7 @@ describe('parse', function() {
     expect(parse(str)).to.deep.equal(obj);
   });
 
-  it('should understand EU4 gameplay settings', function() {
+  it('should understand EU4 gameplay settings', function () {
     var str = 'gameplaysettings=\r\n{\r\n\tsetgameplayoptions=' +
       '\r\n\t{\r\n\t\t1 1 2 0 1 0 0 0 1 1 1 1 \r\n\t}\r\n}';
     var obj = {
@@ -205,7 +205,7 @@ describe('parse', function() {
     expect(parse(str)).to.deep.equal(obj);
   });
 
-  it('should parse multiple objects accumulated', function() {
+  it('should parse multiple objects accumulated', function () {
     var str = 'army=\r\n{\r\n\tname="1st army"\r\n\tunit={\r\n\t\t' +
       'name="1st unit"\r\n\t}\r\n}\r\narmy=\r\n{\r\n\tname="2nd army"' +
       '\r\n\tunit={\r\n\t\tname="1st unit"\r\n\t}\r\n\tunit={\r\n\t\t' +
@@ -230,7 +230,7 @@ describe('parse', function() {
     expect(parse(str)).to.deep.equal(obj);
   });
 
-  it('should handle back to backs', function() {
+  it('should handle back to backs', function () {
     var str1 = 'POR={type=0 max_demand=2.049 t_in=49.697 t_from=\r\n' +
       '{ C00=5.421 C18=44.276 } }';
     var str2 = 'SPA= { type=0 val=3.037 max_pow=1.447 max_demand=2.099 ' +
@@ -241,7 +241,7 @@ describe('parse', function() {
         type: 0,
         max_demand: 2.049,
         t_in: 49.697,
-        t_from: {'C00': 5.421, 'C18': 44.276}
+        t_from: { 'C00': 5.421, 'C18': 44.276 }
       },
       SPA: {
         type: 0,
@@ -250,109 +250,114 @@ describe('parse', function() {
         max_demand: 2.099,
         province_power: 1.447,
         t_in: 44.642,
-        t_from: {'C01': 1.794, 'C17': 42.848}
+        t_from: { 'C01': 1.794, 'C17': 42.848 }
       }
     };
 
     expect(parse(str1 + str2)).to.deep.equal(expected);
   });
 
-  it('should handle dates as identifiers', function() {
-    expect(parse('1480.1.1=yes')).to.deep.equal({'1480.1.1': true});
+  it('should handle dates as identifiers', function () {
+    expect(parse('1480.1.1=yes')).to.deep.equal({ '1480.1.1': true });
   });
 
-  it('should handle consecutive numbers', function() {
-    expect(parse('foo = { 1 -1.23 }')).to.deep.equal({'foo': [1, -1.23]});
+  it('should handle consecutive numbers', function () {
+    expect(parse('foo = { 1 -1.23 }')).to.deep.equal({ 'foo': [1, -1.23] });
   });
 
-  it('should handle consecutive dates', function() {
-    expect(parse('foo = { 1821.1.1 1821.2.1 }')).to.deep.equal({'foo':
-      [new Date(Date.UTC(1821, 0, 1)), new Date(Date.UTC(1821, 1, 1))]});
+  it('should handle consecutive dates', function () {
+    expect(parse('foo = { 1821.1.1 1821.2.1 }')).to.deep.equal({
+      'foo':
+        [new Date(Date.UTC(1821, 0, 1)), new Date(Date.UTC(1821, 1, 1))]
+    });
   });
 
-  it('should understand comments mean skip line', function() {
+  it('should understand comments mean skip line', function () {
     expect(parse('# boo\r\n# baa\r\nfoo=a\r\n# bee')).to.deep.
-        equal({'foo': 'a'});
+      equal({ 'foo': 'a' });
   });
 
-  it('should understand simple objects', function() {
-    expect(parse('foo={bar=val}')).to.deep.equal({'foo': {'bar': 'val'}});
+  it('should understand simple objects', function () {
+    expect(parse('foo={bar=val}')).to.deep.equal({ 'foo': { 'bar': 'val' } });
   });
 
-  it('should understand nested list objects', function() {
-    expect(parse('foo={bar={val}}')).to.deep.equal({'foo': {'bar': ['val']}});
+  it('should understand nested list objects', function () {
+    expect(parse('foo={bar={val}}')).to.deep.equal({ 'foo': { 'bar': ['val'] } });
   });
 
-  it('should understand objects with start spaces', function() {
-    expect(parse('foo= { bar=val}')).to.deep.equal({'foo': {'bar': 'val'}});
+  it('should understand objects with start spaces', function () {
+    expect(parse('foo= { bar=val}')).to.deep.equal({ 'foo': { 'bar': 'val' } });
   });
 
-  it('should understand objects with end spaces', function() {
-    expect(parse('foo={bar=val }')).to.deep.equal({'foo': {'bar': 'val'}});
+  it('should understand objects with end spaces', function () {
+    expect(parse('foo={bar=val }')).to.deep.equal({ 'foo': { 'bar': 'val' } });
   });
 
-  it('should ignore empty objects with no identifier', function() {
+  it('should ignore empty objects with no identifier', function () {
     expect(parse('foo={bar=val} {} { } me=you')).to.deep.
-        equal({foo: {bar: 'val'}, me: 'you'});
+      equal({ foo: { bar: 'val' }, me: 'you' });
   });
 
-  it('should handle strings as identifiers', function() {
-    expect(parse('"foo"="bar"')).to.deep.equal({'foo': 'bar'});
+  it('should handle strings as identifiers', function () {
+    expect(parse('"foo"="bar"')).to.deep.equal({ 'foo': 'bar' });
   });
 
-  it('should handle = as identifier', function() {
-    expect(parse('=="bar"')).to.deep.equal({'=': 'bar'});
+  it('should handle = as identifier', function () {
+    expect(parse('=="bar"')).to.deep.equal({ '=': 'bar' });
   });
 
-  it('should handle dashed identifiers', function() {
-    expect(parse('dashed-identifier=bar')).to.deep.equal({'dashed-identifier': 'bar'});
+  it('should handle dashed identifiers', function () {
+    expect(parse('dashed-identifier=bar')).to.deep.equal({ 'dashed-identifier': 'bar' });
   });
 
-  it('should handle values with colon sign', function() {
-    expect(parse('foo=bar:foo')).to.deep.equal({'foo': 'bar:foo'});
+  it('should handle values with colon sign', function () {
+    expect(parse('foo=bar:foo')).to.deep.equal({ 'foo': 'bar:foo' });
   });
 
-  it('should handle variables', function() {
-      expect(parse('@planet_standard_scale = 11')).to.deep.equal({'@planet_standard_scale': 11});
+  it('should handle variables', function () {
+    expect(parse('@planet_standard_scale = 11')).to.deep.equal({ '@planet_standard_scale': 11 });
   });
 
-  it('should handle hsv', function() {
-      expect(parse('color = hsv { 0.5 0.2 0.8 }')).to.deep.equal({'color': { h: 0.5, s: 0.2, v: 0.8 }});
+  it('should handle hsv', function () {
+    expect(parse('color = hsv { 0.5 0.2 0.8 }')).to.deep.equal({ 'color': { h: 0.5, s: 0.2, v: 0.8 } });
   });
 
-  it('should handle rgb', function() {
-      expect(parse('color = rgb { 100 200 150 }')).to.deep.equal({'color': { r: 100, g: 200, b: 150 }});
+  it('should handle rgb', function () {
+    expect(parse('color = rgb { 100 200 150 }')).to.deep.equal({ 'color': { r: 100, g: 200, b: 150 } });
   });
 
-  it('should handle less than operator', function() {
-      expect(parse("has_level < 2")).to.deep.equal({'has_level': { 'LESS_THAN': 2 }});
+  it('should handle less than operator', function () {
+    expect(parse("has_level < 2")).to.deep.equal({ 'has_level': { 'LESS_THAN': 2 } });
   });
 
-  it('should handle less than operator quotes', function() {
-      expect(parse("\"has_level2\" < 2")).to.deep.equal({'has_level2': { 'LESS_THAN': 2 }});
+  it('should handle less than operator quotes', function () {
+    expect(parse("\"has_level2\" < 2")).to.deep.equal({ 'has_level2': { 'LESS_THAN': 2 } });
   });
 
-  it('should handle less than or equal to operator', function() {
-      expect(parse("has_level <= 2")).to.deep.equal({'has_level': { 'LESS_THAN_EQUAL': 2 }});
+  it('should handle less than or equal to operator', function () {
+    expect(parse("has_level <= 2")).to.deep.equal({ 'has_level': { 'LESS_THAN_EQUAL': 2 } });
   });
 
-  it('should handle less than or equal to operator quotes', function() {
-      expect(parse("\"has_level2\" <= 2")).to.deep.equal({'has_level2': { 'LESS_THAN_EQUAL': 2 }});
+  it('should handle less than or equal to operator quotes', function () {
+    expect(parse("\"has_level2\" <= 2")).to.deep.equal({ 'has_level2': { 'LESS_THAN_EQUAL': 2 } });
   });
 
-  it('should handle greater than operator', function() {
-      expect(parse("has_level > 2")).to.deep.equal({'has_level': { 'GREATER_THAN': 2 }});
+  it('should handle greater than operator', function () {
+    expect(parse("has_level > 2")).to.deep.equal({ 'has_level': { 'GREATER_THAN': 2 } });
   });
 
-  it('should handle greater than operator quotes', function() {
-      expect(parse("\"has_level2\" > 2")).to.deep.equal({'has_level2': { 'GREATER_THAN': 2 }});
+  it('should handle greater than operator quotes', function () {
+    expect(parse("\"has_level2\" > 2")).to.deep.equal({ 'has_level2': { 'GREATER_THAN': 2 } });
   });
 
-  it('should handle greater than or equal to operator', function() {
-      expect(parse("has_level >= 2")).to.deep.equal({'has_level': { 'GREATER_THAN_EQUAL': 2 }});
+  it('should handle greater than or equal to operator', function () {
+    expect(parse("has_level >= 2")).to.deep.equal({ 'has_level': { 'GREATER_THAN_EQUAL': 2 } });
   });
 
-  it('should handle greater than or equal to operator quotes', function() {
-      expect(parse("\"has_level2\" >= 2")).to.deep.equal({'has_level2': { 'GREATER_THAN_EQUAL': 2 }});
+  it('should handle greater than or equal to operator quotes', function () {
+    expect(parse("\"has_level2\" >= 2")).to.deep.equal({ 'has_level2': { 'GREATER_THAN_EQUAL': 2 } });
+  });
+  it('should handle escaped double quotes', function () {
+    expect(parse("desc=\"\\\"Captain\\\"\"")).to.deep.equal({ 'desc': "\\\"Captain\\\"" });
   });
 });


### PR DESCRIPTION
This allows for the value to contain an escaped double quote: `\"`