### PR TITLE
Fix parsing of deceptive dates

### DIFF
--- a/lib/jomini.jison
+++ b/lib/jomini.jison
@@ -10,9 +10,9 @@ var setProp = require('./setProp');
 \s+                   /* skip whitespace */
 "yes"\b               return 'BOOL'
 "no"\b                return 'BOOL'
-[0-9]+"."[0-9]+"."[0-9]+\b return 'DATE'
+[0-9]+"."[0-9]+"."[0-9]+(?=$|[ \t\r\n\{\}\=\!\>\<]) return 'DATE'
 '"'[0-9]+"."[0-9]+"."[0-9]+'"' yytext = yytext.substr(1,yyleng-2); return 'QDATE'
-"-"?[0-9]+("."[0-9]+)?\b  return 'NUMBER'
+"-"?[0-9]+("."[0-9]+)?(?=$|[ \t\r\n\{\}\=\!\>\<])  return 'NUMBER'
 "{"                   return '{'
 "}"                   return '}'
 "hsv"                 return 'hsv'

--- a/test/parse.js
+++ b/test/parse.js
@@ -73,9 +73,9 @@ describe('parse', function () {
       equal({ 'date': new Date(Date.UTC(1821, 0, 1)) });
   });
 
-  /*it('should deceptive dates', function() {
-    expect(parse('date=1821.a.1')).to.deep.equal({date': '1821.a.1'});
-  });*/
+  it('should deceptive dates', function() {
+    expect(parse('date=1821.a.1')).to.deep.equal({'date': '1821.a.1'});
+  });
 
   it('should handle quoted dates', function () {
     expect(parse('date="1821.1.1"')).to.deep.


### PR DESCRIPTION
Previously input that looked numeric could throw off the parser, such as

```
date=1821.a.1
```

It would be parsed as an IDENTIFIER, =, NUMBER(1821), IDENTIFIER(.a.1),
EOF.

This is incorrect. A number should consume all non delimiting characters
(and a period does not constitute a delimiter between fields). Since we
can no longer use regex boundary class `\b`, a postive lookahead had to
be used to ensure that any subsequent characters to a number were
delimiters.

Closes #23

Thanks to @soryy708 for reporting the issue.