### PR TITLE
Use whitelist instead of blacklist

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-coverage/

--- a/package.json
+++ b/package.json
@@ -29,5 +29,12 @@
     "parser",
     "javascript"
   ],
-  "types": "index.d.ts"
+  "types": "index.d.ts",
+  "files": [
+    "/lib/*.js",
+    "/lib/jomini.jison",
+    "/cli.js",
+    "/index.js",
+    "/index.d.ts"
+  ]
 }


### PR DESCRIPTION
Handles https://github.com/nickbabcock/jomini/issues/26

I'm curious about the impact on "unpacked size" on npm (currently 53kB).