### PR TITLE
CI: build on pull requests and use npm install

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,6 @@
 name: Node CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -20,7 +20,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: npm install, build, and test
       run: |
-        npm ci
+        npm install
         npm run build --if-present
         npm test
       env:


### PR DESCRIPTION
npm ci no longer works as we aren't using a package-lock.json anymore as
jomini is a library