### PR TITLE
Generate JSON API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Jomini is a javascript library that is able to parse **plaintext** save and game
 ## Features:
 
 - ✔ Compatibility: Node 12+ and >90% of browsers
-- ✔ Speed: Parse at nearly 200 MB/s
+- ✔ Speed: Parse at over 200 MB/s
 - ✔ Correctness: The same parser underpins [Rakaly](https://rakaly.com/eu4), the EU4 achievement leaderboard, and the [Paradox Game Converters's](https://github.com/ParadoxGameConverters/EU4toVic2) ironman to plaintext converter
-- ✔ Ergonomic: Data parsed into plain javascript objects
+- ✔ Ergonomic: Data parsed into plain javascript objects or JSON
 - ✔ Self-contained: zero runtime dependencies
-- ✔ Small: Less than 50 KB when gzipped
+- ✔ Small: Less than 60 KB when gzipped
 
 ## Install
 
@@ -100,6 +100,25 @@ const prestige = save.countries[player].prestige;
 ```
 
 The faster version completes 40x faster (6.3s vs 0.16s) and uses about half the memory.
+
+## JSON
+
+There is a middle ground in terms of performance and flexibility: using JSON as an intermediate layer:
+
+```js
+const buffer = readFileSync(args[0]);
+const parser = await Jomini.initialize();
+const out = parser.parseText(buffer, { encoding: "windows1252" }, (q) => q.json());
+const save = JSON.parse(out);
+const player = save.player;
+const prestige = save.countries[player].prestige;
+```
+
+The keys of the stringified JSON object are in the order as they appear in the file, so this makes the JSON approach well suited for parsing files where the order of object keys matter. The other APIs are subjected to natively constructed JS objects reordering keys to suit their fancy. To process the JSON and not lose key order, you'll want to leverage a streaming JSON parser like [oboe.js](https://github.com/jimhigson/oboe.js) or [stream-json](https://github.com/uhop/stream-json).
+
+Interestingly, even though using JSON adds a layer, constructing and parsing the JSON into a JS object is still 3x faster than when a JS object is constructed directly. This must be a testament to how tuned browser JSON parsers are.
+
+The JSON format does not change how dates are encoded, so dates are written into the JSON exactly as they appear in the original file.
 
 ## Data Mangling
 

--- a/cli.js
+++ b/cli.js
@@ -19,7 +19,15 @@ console.timeLog("read file");
   const parser2 = await Jomini.initialize();
   console.timeLog("initialize jomini2");
 
-  console.time("parse text");
+  console.time("parse text")
+  parser.parseText(buffer, { encoding: "windows1252" }, (_) => null);
+  console.timeLog("parse text");
+
+  console.time("parse text whole")
+  parser.parseText(buffer, { encoding: "windows1252" });
+  console.timeLog("parse text whole");
+
+  console.time("parse text at");
   const { player, prestige } = parser.parseText(
     buffer,
     { encoding: "windows1252" },
@@ -30,5 +38,17 @@ console.timeLog("read file");
     }
   );
   console.log(`player: ${player} | prestige: ${prestige}`);
-  console.timeLog("parse text");
+  console.timeLog("parse text at");
+
+  console.time("parse text json");
+  const out = parser.parseText(
+    buffer,
+    { encoding: "windows1252" },
+    (query) => query.json(),
+  );
+  console.timeLog("parse text json");
+
+  console.time("parse json")
+  JSON.parse(out);
+  console.timeLog("parse json")
 })();

--- a/crate/Cargo.lock
+++ b/crate/Cargo.lock
@@ -29,6 +29,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
 name = "jomini"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,6 +46,8 @@ version = "0.1.0"
 dependencies = [
  "jomini",
  "js-sys",
+ "serde",
+ "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-test",
  "wee_alloc",
@@ -100,10 +108,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
+name = "serde"
+version = "1.0.124"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
+
+[[package]]
+name = "serde_json"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "syn"

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -12,6 +12,8 @@ wasm-bindgen = "0.2"
 js-sys = "0.3"
 jomini = { version = "0.9", default-features = false }
 wee_alloc = "0.4"
+serde_json = "1"
+serde = "1"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/crate/src/op.rs
+++ b/crate/src/op.rs
@@ -1,0 +1,10 @@
+use jomini::Operator;
+
+pub fn operator_name(op: Operator) -> &'static str {
+    match op {
+        Operator::LessThan => "LESS_THAN",
+        Operator::LessThanEqual => "LESS_THAN_EQUAL",
+        Operator::GreaterThan => "GREATER_THAN",
+        Operator::GreaterThanEqual => "GREATER_THAN_EQUAL",
+    }
+}

--- a/crate/src/ser.rs
+++ b/crate/src/ser.rs
@@ -1,0 +1,183 @@
+use crate::op;
+use jomini::{ArrayReader, Encoding, ObjectReader, Operator, TextTape, TextToken, ValueReader};
+use serde::{
+    ser::{SerializeMap, SerializeSeq},
+    Serialize, Serializer,
+};
+use std::{cell::RefCell, ops::Deref};
+
+fn serialize_scalar<E, S>(reader: &ValueReader<E>, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    E: Encoding + Clone,
+{
+    let scalar = reader.read_scalar().unwrap();
+    if let Ok(x) = scalar.to_bool() {
+        return s.serialize_bool(x);
+    }
+
+    if let Ok(x) = scalar.to_u64() {
+        return s.serialize_u64(x);
+    }
+
+    if let Ok(x) = scalar.to_i64() {
+        return s.serialize_i64(x);
+    }
+
+    if let Ok(x) = scalar.to_f64() {
+        return s.serialize_f64(x);
+    }
+
+    s.serialize_str(reader.read_str().unwrap().deref())
+}
+
+pub(crate) struct SerValue<'data, 'tokens, 'reader, E> {
+    reader: &'reader ValueReader<'data, 'tokens, E>,
+}
+
+impl<'data, 'tokens, 'reader, E> Serialize for SerValue<'data, 'tokens, 'reader, E>
+where
+    E: Encoding + Clone,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self.reader.token() {
+            TextToken::Quoted(_) | TextToken::Unquoted(_) => {
+                serialize_scalar(&self.reader, serializer)
+            }
+            TextToken::Array(_) => {
+                let array_reader = self.reader.read_array().unwrap();
+                let seq = SerArray {
+                    reader: RefCell::new(array_reader),
+                };
+                seq.serialize(serializer)
+            }
+            TextToken::Object(_) | TextToken::HiddenObject(_) => {
+                let object_reader = self.reader.read_object().unwrap();
+                let map = SerTape {
+                    reader: RefCell::new(object_reader),
+                };
+                map.serialize(serializer)
+            }
+            TextToken::Header(_) => {
+                let mut arr = self.reader.read_array().unwrap();
+                let key_reader = arr.next_value().unwrap();
+                let value_reader = arr.next_value().unwrap();
+
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry(
+                    &key_reader.read_str().unwrap(),
+                    &SerValue {
+                        reader: &value_reader,
+                    },
+                )?;
+                map.end()
+            }
+            TextToken::End(_) | TextToken::Operator(_) => serializer.serialize_none(),
+        }
+    }
+}
+
+pub(crate) struct SerTape<'data, 'tokens, E> {
+    reader: RefCell<ObjectReader<'data, 'tokens, E>>,
+}
+
+impl<'data, 'tokens, E> SerTape<'data, 'tokens, E>
+where
+    E: Encoding + Clone,
+{
+    pub fn new(tape: &'tokens TextTape<'data>, encoding: E) -> Self {
+        SerTape {
+            reader: RefCell::new(ObjectReader::new(tape, encoding)),
+        }
+    }
+}
+
+impl<'data, 'tokens, E> Serialize for SerTape<'data, 'tokens, E>
+where
+    E: Encoding + Clone,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut reader = self.reader.borrow_mut();
+        let mut map = serializer.serialize_map(None)?;
+        while let Some((key, mut entries)) = reader.next_fields() {
+            if entries.len() == 1 {
+                let (op, val) = entries.pop().unwrap();
+                let v = OperatorValue {
+                    operator: op,
+                    value: val,
+                };
+
+                map.serialize_entry(&key.read_str(), &v)?;
+            } else {
+                let values: Vec<_> = entries
+                    .into_iter()
+                    .map(|(op, val)| OperatorValue {
+                        operator: op,
+                        value: val,
+                    })
+                    .collect();
+                map.serialize_entry(&key.read_str(), &values)?;
+            }
+        }
+
+        map.end()
+    }
+}
+
+pub(crate) struct OperatorValue<'data, 'tokens, E> {
+    operator: Option<Operator>,
+    value: ValueReader<'data, 'tokens, E>,
+}
+
+impl<'data, 'tokens, E> Serialize for OperatorValue<'data, 'tokens, E>
+where
+    E: Encoding + Clone,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if let Some(op) = self.operator {
+            let mut map = serializer.serialize_map(None)?;
+            let reader = &self.value;
+            map.serialize_entry(op::operator_name(op), &SerValue { reader })?;
+            map.end()
+        } else {
+            let reader = &self.value;
+            let vs = SerValue { reader };
+            vs.serialize(serializer)
+        }
+    }
+}
+
+pub(crate) struct SerArray<'data, 'tokens, E> {
+    reader: RefCell<ArrayReader<'data, 'tokens, E>>,
+}
+
+impl<'data, 'tokens, E> Serialize for SerArray<'data, 'tokens, E>
+where
+    E: Encoding + Clone,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut reader = self.reader.borrow_mut();
+        let mut seq = serializer.serialize_seq(None)?;
+        while let Some(value) = reader.next_value() {
+            let v = OperatorValue {
+                operator: None,
+                value,
+            };
+            seq.serialize_element(&v)?;
+        }
+
+        seq.end()
+    }
+}

--- a/tests/test.js
+++ b/tests/test.js
@@ -539,3 +539,65 @@ test("should parse subsequent unordered objects", async (t) => {
   };
   t.deepEqual(await parse(str), expected);
 });
+
+test("should serialize to json", async (t) => {
+  const jomini = await Jomini.initialize();
+  const str = "foo=bar";
+  const expected = '{"foo":"bar"}';
+  const out = jomini.parseText(utf8encode(str), {}, (q) =>
+    q.json()
+  );
+  t.deepEqual(out, expected);
+});
+
+test("should serialize to json simple types", async (t) => {
+  const jomini = await Jomini.initialize();
+  const str = "foo=bar num=1 bool=no bool2=yes pi=3.14";
+  const expected = '{"foo":"bar","num":1,"bool":false,"bool2":true,"pi":3.14}';
+  const out = jomini.parseText(utf8encode(str), {}, (q) =>
+    q.json()
+  );
+  t.deepEqual(out, expected);
+});
+
+test("should serialize to json object", async (t) => {
+  const jomini = await Jomini.initialize();
+  const str = "foo={prop=a bar={num=1}}";
+  const expected = '{"foo":{"prop":"a","bar":{"num":1}}}';
+  const out = jomini.parseText(utf8encode(str), {}, (q) =>
+    q.json()
+  );
+  t.deepEqual(out, expected);
+});
+
+
+test("should serialize to json array", async (t) => {
+  const jomini = await Jomini.initialize();
+  const str = "nums={1 2 3 4}";
+  const expected = '{"nums":[1,2,3,4]}';
+  const out = jomini.parseText(utf8encode(str), {}, (q) =>
+    q.json()
+  );
+  t.deepEqual(out, expected);
+});
+
+test("should serialize to json consecutive field values", async (t) => {
+  const jomini = await Jomini.initialize();
+  const str = "core=AAA core=BBB";
+  const expected = '{"core":["AAA","BBB"]}';
+  const out = jomini.parseText(utf8encode(str), {}, (q) =>
+    q.json()
+  );
+  t.deepEqual(out, expected);
+});
+
+test("should serialize to json header", async (t) => {
+  const jomini = await Jomini.initialize();
+  const str = "color = rgb { 100 200 150 }";
+  const expected = '{"color":{"rgb":[100,200,150]}}';
+  const out = jomini.parseText(utf8encode(str), {}, (q) =>
+    q.json()
+  );
+  t.deepEqual(out, expected);
+});
+


### PR DESCRIPTION
There is a middle ground in terms of performance and flexibility: using
JSON as an intermediate layer:

```js
const buffer = readFileSync(args[0]);
const parser = await Jomini.initialize();
const out = parser.parseText(buffer, { encoding: "windows1252" }, (q) => q.json());
const save = JSON.parse(out);
const player = save.player;
const prestige = save.countries[player].prestige;
```

The keys of the stringified JSON object are in the order as they appear
in the file, so this makes the JSON approach well suited for parsing
files where the order of object keys matter. The other APIs are
subjected to natively constructed JS objects reordering keys to suit
their fancy. To process the JSON and not lose key order, you'll want to
leverage a streaming JSON parser like
[oboe.js](https://github.com/jimhigson/oboe.js) or
[stream-json](https://github.com/uhop/stream-json).

Interestingly, even though using JSON adds a layer, constructing and
parsing the JSON into a JS object is still 3x faster than when a JS
object is constructed directly. This must be a testament to how tuned
browser JSON parsers are.

The JSON format does not change how dates are encoded, so dates are
written into the JSON exactly as they appear in the original file.

The biggest downside is that this adds 20KB to the gzipped payload as we
now have to include a JSON library. This seems tolerable.