### PR TITLE
Preserve precision in unsafe integers with strings

### DIFF
--- a/crate/Cargo.lock
+++ b/crate/Cargo.lock
@@ -36,9 +36,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "jomini"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f18a494691a13f1b8e80f3e99c4bfdf8e09d3957793a57e89f37a2a1fffc111"
+checksum = "aa8e6e602ef0e1b23ca6f2defe7eeec59647e60ee75044c93821072b9b2ebd97"
 
 [[package]]
 name = "jomini-js"

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 wasm-bindgen = "0.2"
 js-sys = "0.3"
-jomini = { version = "0.9", default-features = false }
+jomini = { version = "0.10", default-features = false }
 wee_alloc = "0.4"
 serde_json = "1"
 serde = "1"

--- a/crate/src/ser.rs
+++ b/crate/src/ser.rs
@@ -16,19 +16,18 @@ where
         return s.serialize_bool(x);
     }
 
-    if let Ok(x) = scalar.to_u64() {
-        return s.serialize_u64(x);
-    }
+    let signed = scalar.to_i64();
+    let unsigned = scalar.to_u64();
+    let float = scalar.to_f64();
 
-    if let Ok(x) = scalar.to_i64() {
-        return s.serialize_i64(x);
+    // We only want to serialize numbers that are perfectly representable
+    // with 64 bit floating point, else the value will be stringified
+    match (signed, unsigned, float) {
+        (Ok(x), _, Ok(_)) => s.serialize_i64(x),
+        (_, Ok(x), Ok(_)) => s.serialize_u64(x),
+        (_, _, Ok(f)) => s.serialize_f64(f),
+        _ => s.serialize_str(reader.read_str().unwrap().deref()),
     }
-
-    if let Ok(x) = scalar.to_f64() {
-        return s.serialize_f64(x);
-    }
-
-    s.serialize_str(reader.read_str().unwrap().deref())
 }
 
 pub(crate) struct SerValue<'data, 'tokens, 'reader, E> {

--- a/tests/test.js
+++ b/tests/test.js
@@ -434,6 +434,19 @@ test("should handle less than operator object", async (t) => {
   });
 });
 
+test("should serialize large numbers as strings", async (t) => {
+  t.deepEqual(await parse("val = 18446744073709547616"), {
+    val: "18446744073709547616",
+  });
+});
+
+test("should serialize large negative numbers as strings", async (t) => {
+  t.deepEqual(await parse("val = -90071992547409097"), {
+    val: "-90071992547409097",
+  });
+});
+
+
 test("should handle hsv", async (t) => {
   t.deepEqual(await parse("color = hsv { 0.5 0.2 0.8 }"), {
     color: { hsv: [0.5, 0.2, 0.8] },
@@ -595,6 +608,26 @@ test("should serialize to json header", async (t) => {
   const jomini = await Jomini.initialize();
   const str = "color = rgb { 100 200 150 }";
   const expected = '{"color":{"rgb":[100,200,150]}}';
+  const out = jomini.parseText(utf8encode(str), {}, (q) =>
+    q.json()
+  );
+  t.deepEqual(out, expected);
+});
+
+test("should serialize large numbers as strings in json", async (t) => {
+  const jomini = await Jomini.initialize();
+  const str = "identity = 18446744073709547616";
+  const expected = '{"identity":"18446744073709547616"}';
+  const out = jomini.parseText(utf8encode(str), {}, (q) =>
+    q.json()
+  );
+  t.deepEqual(out, expected);
+});
+
+test("should serialize large negative numbers as strings in json", async (t) => {
+  const jomini = await Jomini.initialize();
+  const str = "identity = -90071992547409097";
+  const expected = '{"identity":"-90071992547409097"}';
   const out = jomini.parseText(utf8encode(str), {}, (q) =>
     q.json()
   );


### PR DESCRIPTION
Javascript only has 64 bit floating point numbers. This means that there
are 64 bit integers that can't be represented with floating point
without losing precision. Since some PDS games use 64 bit integers as
identifiers we don't want to risk losing precision in these identifiers.

The fix is to detect when these numbers fall outside the range and when
they do, encode them as strings instead of numbers.