### PR TITLE
Add disambiguation option to duplicate keys in JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Jomini is a javascript library that is able to parse **plaintext** save and game
 - ✔ Correctness: The same parser underpins [Rakaly](https://rakaly.com/eu4), the EU4 achievement leaderboard, and the [Paradox Game Converters's](https://github.com/ParadoxGameConverters/EU4toVic2) ironman to plaintext converter
 - ✔ Ergonomic: Data parsed into plain javascript objects or JSON
 - ✔ Self-contained: zero runtime dependencies
-- ✔ Small: 70 KB when gzipped
+- ✔ Small: 75 KB when gzipped
 
 ## Install
 
@@ -119,6 +119,64 @@ The keys of the stringified JSON object are in the order as they appear in the f
 Interestingly, even though using JSON adds a layer, constructing and parsing the JSON into a JS object is still 3x faster than when a JS object is constructed directly. This must be a testament to how tuned browser JSON parsers are.
 
 The JSON format does not change how dates are encoded, so dates are written into the JSON exactly as they appear in the original file.
+
+The JSON generator contains options to tweak the output.
+
+To pretty print the output:
+
+```js
+parser.parseText(buffer, { }, (q) => q.json({ pretty: true }));
+```
+
+There is an option to decide how duplicate keys are disambiguated. For instance, given the following data:
+
+```
+core="AAA"
+core="BBB"
+```
+
+The default behavior (the disambiguation of "none") will encode the above as:
+
+```json
+{
+  "core": ["AAA", "BBB"]
+}
+```
+
+The default behavior favors ergonomics over preserving structure as most users probably aren't in need to know if a JSON array appeared as an array in the data. This behavior can be tweaked so that duplicate keys are retained:
+
+```js
+parser.parseText(buffer, { }, (q) => q.json({ disambiguate: "keys" }));
+```
+
+will output:
+
+```json
+{
+  "core": "AAA",
+  "core": "BBB"
+}
+```
+
+But whether or not the above is [valid JSON is debateable](https://stackoverflow.com/q/21832701). So the last disambiguation mode transforms key value objects to an array of key value tuples:
+
+```js
+parser.parseText(buffer, { }, (q) => q.json({ disambiguate: "typed" }));
+```
+
+will output:
+
+```json
+{
+  "type": "obj",
+  "val": [
+    ["core", "AAA"],
+    ["core", "BBB"]
+  ]
+}
+```
+
+The output is ugly and verbose, but it's valid JSON and preserves the original structure. Arrays will have the type of `array`.
 
 ## Data Mangling
 

--- a/src/jomini.ts
+++ b/src/jomini.ts
@@ -80,6 +80,17 @@ export class Jomini {
    * If the JSON should be pretty-printed. Defaults to false
    */
   pretty: boolean;
+
+  /**
+   * Determines how duplicate keys are disambiguated from arrays. The default of
+   * "none" means that there is no disambiguation and that duplicate keys will
+   * be aggregated into an array and appear similar to other arrays. "keys" will
+   * write duplicate keys back into the JSON but it is debateable whether duplicate
+   * keys is considered valid JSON. "typed" is an overly verbose format that translates
+   * objects into arrays of key value tuples -- arrays are also transformed in this
+   * process to explicitly list their type as `array`
+   */
+  disambiguate: "none" | "keys" | "typed";
 };
 
 export class Query {
@@ -105,7 +116,7 @@ export class Query {
   json(
     options?: Partial<JsonOptions>,
   ): string {
-    return this.query.json(options?.pretty || false);
+    return this.query.json(options?.pretty || false, options?.disambiguate || "none");
   }
 
   /** Internal, do not use */

--- a/tests/test.js
+++ b/tests/test.js
@@ -650,3 +650,33 @@ test("should serialize to json object pretty", async (t) => {
   );
   t.deepEqual(out, expected);
 });
+
+test("should serialize to json disambiguate keys", async (t) => {
+  const jomini = await Jomini.initialize();
+  const str = "core=AAA core=BBB";
+  const expected = '{"core":"AAA","core":"BBB"}';
+  const out = jomini.parseText(utf8encode(str), {}, (q) =>
+    q.json({ disambiguate: "keys" })
+  );
+  t.deepEqual(out, expected);
+});
+
+test("should serialize to json disambiguate typed", async (t) => {
+  const jomini = await Jomini.initialize();
+  const str = "core=AAA core=BBB";
+  const expected = '{"type":"obj","val":[["core","AAA"],["core","BBB"]]}';
+  const out = jomini.parseText(utf8encode(str), {}, (q) =>
+    q.json({ disambiguate: "typed" })
+  );
+  t.deepEqual(out, expected);
+});
+
+test("should serialize to json disambiguate typed arrays", async (t) => {
+  const jomini = await Jomini.initialize();
+  const str = "nums={1 2}";
+  const expected = '{"type":"obj","val":[["nums",{"type":"array","val":[1,2]}]]}';
+  const out = jomini.parseText(utf8encode(str), {}, (q) =>
+    q.json({ disambiguate: "typed" })
+  );
+  t.deepEqual(out, expected);
+});


### PR DESCRIPTION
Previously duplicate keys:

```
core="AAA"
core="BBB"
```

would be coalesced into an array in the JSON output. This is suboptimal
for users that need to distinguish between duplicated keys and / or the
order that keys occur in. The fix is to add a `disambiguate` where one
specifies whether they want duplicated keys in their JSON (and land in
the grey area of validity) or transform objects into an array of key
value tuples.