### PR TITLE
Ergonomically expose object trailer

### DIFF
--- a/crate/Cargo.lock
+++ b/crate/Cargo.lock
@@ -36,9 +36,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "jomini"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3160df32af40cc6412c75913d90c2885c80c2a4eca3b53425a4bf963095dda4a"
+checksum = "34385e04f9d4a0b87cc795f82697cf147cb9419b9946ffb5aba05477eb4ad072"
 
 [[package]]
 name = "jomini-js"

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 wasm-bindgen = "0.2"
 js-sys = "0.3"
-jomini = { version = "0.10", default-features = false }
+jomini = { version = "0.11", default-features = false }
 wee_alloc = "0.4"
 serde_json = "1"
 serde = "1"

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -230,6 +230,10 @@ where
             result.set(key_js, value_js);
         }
 
+        if let Some(trailer) = reader.at_trailer() {
+            result.set(JsValue::from_str("trailer"), self.create_array(trailer));
+        }
+
         result
     }
 

--- a/crate/src/ser.rs
+++ b/crate/src/ser.rs
@@ -143,6 +143,14 @@ where
                     }
                 }
 
+                if let Some(trailer) = reader.at_trailer() {
+                    let seq = SerArray {
+                        reader: RefCell::new(trailer),
+                        mode: self.mode,
+                    };
+                    map.serialize_entry("trailer", &seq)?;
+                }
+
                 map.end()
             }
             DisambiguateMode::Keys => {
@@ -155,6 +163,14 @@ where
                         mode: self.mode,
                     };
                     map.serialize_entry(&key.read_str(), &v)?;
+                }
+
+                if let Some(trailer) = reader.at_trailer() {
+                    let seq = SerArray {
+                        reader: RefCell::new(trailer),
+                        mode: self.mode,
+                    };
+                    map.serialize_entry("trailer", &seq)?;
                 }
 
                 map.end()
@@ -290,6 +306,15 @@ where
                 mode: self.mode,
             };
             seq.serialize_element(&(key.read_str(), &v))?;
+        }
+
+        if let Some(trailer) = reader.at_trailer() {
+            let trailer_array = InnerSerArray {
+                reader: RefCell::new(trailer),
+                mode: self.mode,
+            };
+
+            seq.serialize_element(&trailer_array)?;
         }
 
         seq.end()


### PR DESCRIPTION
A document with an object trailer:

```
area = { color = { 10 } 1 2 }
```

The trailing "1 2" is referred to as the object trailer and will now be
exposed as the `trailer` property:

```js
area: { color: [10], trailer: [1, 2] }
```

Instead of the old behavior of trying to interpret the values as key
value pairs as demonstrated in #53