### PR TITLE
Increase test timeout to account for CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "wasm-pack build -t web --out-dir ../src/pkg crate && rm -rf dist/ && rollup -c",
     "pretest": "npm run build",
-    "test": "ava && tsc --target esnext --moduleResolution node --noEmit tests/usage.ts",
+    "test": "ava --timeout=2m && tsc --target esnext --moduleResolution node --noEmit tests/usage.ts",
     "prepublishOnly": "npm test"
   },
   "repository": {


### PR DESCRIPTION
Not sure why the tests are so flaky with timeouts, so increase the
timeout from the default 10 seconds to 2 minutes