### PR TITLE
Support Eu4 parameter definitions

### DIFF
--- a/crate/Cargo.lock
+++ b/crate/Cargo.lock
@@ -36,9 +36,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "jomini"
-version = "0.11.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9919d1c9dbbfbcd50cf4b73642411f6a1981aa6ce2bdab378274cab5cc6f5f77"
+checksum = "d165a33c58b6282727739754292c3293fef5235af036276e32cf4ee09bc11879"
 
 [[package]]
 name = "jomini-js"

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 wasm-bindgen = "0.2"
 js-sys = "0.3"
-jomini = { version = "0.11", default-features = false }
+jomini = { version = "0.12", default-features = false }
 wee_alloc = "0.4"
 serde_json = "1"
 serde = "1"

--- a/tests/test.js
+++ b/tests/test.js
@@ -135,6 +135,18 @@ test("should handle empty object", async (t) => {
   t.deepEqual(await parse("foo = {}"), { foo: {} });
 });
 
+test("should handle parameter definition value", async (t) => {
+  t.deepEqual(await parse("foo = { [[add] $add$]}"), { foo: { "[add]": "$add$" } });
+});
+
+test("should handle parameter definitions", async (t) => {
+  t.deepEqual(await parse("foo = { [[add] if={a=b}]}"), { foo: { "[add]": {if: {a: "b"}}} });
+});
+
+test("should handle undefined parameter definitions", async (t) => {
+  t.deepEqual(await parse("foo = { [[!add] if={a=b}]}"), { foo: { "[!add]": {if: {a: "b"}}} });
+});
+
 test("should parse through extra trailing brace", async (t) => {
   t.deepEqual(await parse("foo = { bar } }"), { foo: ["bar"] });
 });
@@ -703,6 +715,27 @@ test("should serialize object trailers to json typed", async (t) => {
   const str = "area = { color = { 10 } 1 2 }";
   const expected =
     '{"type":"obj","val":[["area",{"type":"obj","val":[["color",{"type":"array","val":[10]}],[1,2]]}]]}';
+  const out = jomini.parseText(utf8encode(str), {}, (q) =>
+    q.json({ disambiguate: "typed" })
+  );
+  t.deepEqual(out, expected);
+});
+
+test("should serialize parameter definitions to json typed", async (t) => {
+  const jomini = await Jomini.initialize();
+  const str = "generate_advisor = { [[scaled_skill] a=b ] [[!scaled_skill] c=d ]  }";
+  const expected =
+    '{"type":"obj","val":[["generate_advisor",{"type":"obj","val":[["[scaled_skill]",{"type":"obj","val":[["a","b"]]}],["[!scaled_skill]",{"type":"obj","val":[["c","d"]]}]]}]]}';
+  const out = jomini.parseText(utf8encode(str), {}, (q) =>
+    q.json({ disambiguate: "typed" })
+  );
+  t.deepEqual(out, expected);
+});
+
+test("should serialize parameter definition value to json typed", async (t) => {
+  const jomini = await Jomini.initialize();
+  const str = "foo = { [[add] $add$]}";
+  const expected = '{"type":"obj","val":[["foo",{"type":"obj","val":[["[add]","$add$"]]}]]}';
   const out = jomini.parseText(utf8encode(str), {}, (q) =>
     q.json({ disambiguate: "typed" })
   );


### PR DESCRIPTION
See: https://github.com/rakaly/jomini/pull/63

On the JS side, we encode parameters enclosed in hard braces so that
users will have a good heuristics if something is a parameter by
examining the first character of an object's key.