### PR TITLE
Add export map and UMD build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,13 @@
   "author": "Nick Babcock <nbabcock19@hotmail.com>",
   "license": "MIT",
   "description": "Parses Paradox files into javascript objects",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
+  "main": "./dist/umd/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/es/index.js",
+      "default": "./dist/cjs/index.js"
+    }
+  },
   "types": "./dist/es/index.d.ts",
   "files": [
     "dist"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -36,4 +36,4 @@ const rolls = (fmt) => ({
   ],
 });
 
-export default [rolls("cjs"), rolls("es")];
+export default [rolls("umd"), rolls("cjs"), rolls("es")];


### PR DESCRIPTION
The UMD build should make it easier to host on a CDN for users to test
out (and they aren't familiar or can't use a package manager).

The export map follows the guidelines here: https://nodejs.org/api/packages.html#package-entry-points

We now score 100% on skypack quality: https://docs.skypack.dev/package-authors/package-checks