### PR TITLE
Add slim module without base64 inlined Wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node: ['12.x', '14.x']
+        node: ['14.x', '16.x']
 
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -273,3 +273,18 @@ t.deepEqual(
   'data={\n  settings={\n    0 1\n  }\n  name="world"\n}\ncolor=rgb {\n  100 150 74\n}\nstart=1444.11.11\n'
 );
 ```
+
+## Slim Module
+
+By default, the `jomini` entrypoint includes Wasm that is base64 inlined. This is the default as most developers will probably not need to care. However some developers will care: those running the library in environments where Wasm is executable but not compileable or those who are ambitious about reducing compute and bandwidth costs for their users.
+
+To cater to these use cases, there is a `jomini/slim` package that operates the exactly the same except now it is expected for developers to prime initialization through some other means:
+
+```js
+import { Jomini } from "jomini/slim";
+import wasm from "jomini/jomini.wasm";
+
+const data = `player="FRA"`;
+const parser = await Jomini.initialize({ wasm });
+const out = parser.parseText(data);
+```

--- a/package.json
+++ b/package.json
@@ -9,14 +9,19 @@
     ".": {
       "import": "./dist/es/index.js",
       "default": "./dist/cjs/index.js"
-    }
+    },
+    "./slim": {
+      "import": "./dist/es-slim/index.js",
+      "default": "./dist/cjs-slim/index.js"
+    },
+    "./jomini.wasm": "./dist/jomini.wasm"
   },
   "types": "./dist/es/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "wasm-pack build -t web --out-dir ../src/pkg crate && rm -rf dist/ && rollup -c",
+    "build": "wasm-pack build -t web --out-dir ../src/pkg crate && rm -rf dist/ && rollup -c && cp src/pkg/jomini_js_bg.wasm dist/jomini.wasm",
     "build:minify": "npm run build && npx terser@latest --compress --mangle --output dist/es/index.js -- dist/es/index.js",
     "pretest": "npm run build",
     "test": "ava --timeout=2m && tsc --target esnext --moduleResolution node --noEmit tests/usage.ts",

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,4 +1,5 @@
 const test = require("ava");
+const fs = require("fs/promises");
 const { Jomini, toArray } = require("..");
 
 const encoder = new TextEncoder();
@@ -838,4 +839,14 @@ test("should write escaped text", async (t) => {
   });
 
   t.deepEqual(new TextDecoder().decode(out), 'name="Project \\"Eagle\\""\n');
+});
+
+test("should allow custom initialization", async (t) => {
+  let jomini = await Jomini.initialize();
+  Jomini.resetModule();
+  const wasm = await fs.readFile("dist/jomini.wasm");
+  jomini = await Jomini.initialize({ wasm });
+
+  const out = jomini.parseText("foo=bar");
+  t.deepEqual(out, { "foo": "bar" });
 });


### PR DESCRIPTION
By default, the `jomini` entrypoint includes Wasm that is base64
inlined. This is the default as most developers will probably not need
to care. However some developers will care: those running the library in
environments where Wasm is executable but not compileable or those who
are ambitious about reducing compute and bandwidth costs for their
users.

To cater to these use cases, there is a `jomini/slim` package that
operates the exactly the same except now it is expected for developers
to prime initialization through some other means:

```js
import { Jomini } from "jomini/slim";
import wasm from "jomini/jomini.wasm";

const data = `player="FRA"`;
const parser = await Jomini.initialize({ wasm });
const out = parser.parseText(data);
```