### PR TITLE
Bump parser to support mixed container edge cases

### DIFF
--- a/crate/Cargo.lock
+++ b/crate/Cargo.lock
@@ -32,9 +32,9 @@ checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "jomini"
-version = "0.20.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62c072d9234b3deb0f732326e636672aa93f28ca7650dcff271b27fe775efaf1"
+checksum = "2e86d4b770f0ef605045a909617ffa9808e8e9ffa9a2d5457cc6d4df8c59b0d2"
 dependencies = [
  "jomini_derive",
  "serde",
@@ -120,6 +120,20 @@ name = "serde"
 version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7af873f2c95b99fcb0bd0fe622a43e29514658873c8ceba88c4cb88833a22500"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.141"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75743a150d003dd863b51dc809bcad0d73f2102c53632f1e954e738192a3413f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 wasm-bindgen = "0.2"
 js-sys = "0.3"
-jomini = { version = "0.20", features = ["json"] }
+jomini = { version = "0.20.2", features = ["json"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/tests/jomini.test.ts
+++ b/tests/jomini.test.ts
@@ -757,6 +757,44 @@ it("should serialize object trailers to json typed", async () => {
   expect(out).toEqual(expected);
 });
 
+it("should serialize mixed objects to json", async () => {
+  const jomini = await Jomini.initialize();
+  const str = `
+  on_actions = {
+    faith_holy_order_land_acquisition_pulse
+    delay = { days = { 5 10 }}
+    faith_heresy_events_pulse
+    delay = { days = { 15 20 }}
+    faith_fervor_events_pulse
+  }
+`;
+  const expected =
+    '{"on_actions":["faith_holy_order_land_acquisition_pulse",{"delay":{"days":[5,10]}},"faith_heresy_events_pulse",{"delay":{"days":[15,20]}},"faith_fervor_events_pulse"]}';
+
+  const out = jomini.parseText(utf8encode(str), {}, (q) => q.json());
+  expect(out).toEqual(expected);
+});
+
+it("should serialize mixed objects to json keys", async () => {
+  const jomini = await Jomini.initialize();
+  const str = `
+  on_actions = {
+    faith_holy_order_land_acquisition_pulse
+    delay = { days = { 5 10 }}
+    faith_heresy_events_pulse
+    delay = { days = { 15 20 }}
+    faith_fervor_events_pulse
+  }
+`;
+  const expected =
+    '{"on_actions":["faith_holy_order_land_acquisition_pulse",{"delay":{"days":[5,10]}},"faith_heresy_events_pulse",{"delay":{"days":[15,20]}},"faith_fervor_events_pulse"]}';
+
+  const out = jomini.parseText(utf8encode(str), {}, (q) =>
+    q.json({ duplicateKeyMode: "preserve" })
+  );
+  expect(out).toEqual(expected);
+});
+
 it("should serialize parameter definitions to json typed", async () => {
   const jomini = await Jomini.initialize();
   const str =


### PR DESCRIPTION
This release supports the following

```
on_actions = {
  faith_holy_order_land_acquisition_pulse
  delay = { days = { 5 10 }}
  faith_heresy_events_pulse
  delay = { days = { 15 20 }}
  faith_fervor_events_pulse
}
```