### PR TITLE
Update type authoring and target output

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,16 +8,16 @@
   "type": "module",
   "main": "./dist/umd/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/umd/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/cjs/index.d.ts",
+      "types": "./dist/types/index.d.ts",
       "node": "./dist/node/index.cjs",
       "import": "./dist/es/index.js",
       "default": "./dist/cjs/index.cjs"
     },
     "./slim": {
-      "types": "./dist/cjs-slim/index_slim.d.ts",
+      "types": "./dist/types/index.d.ts",
       "node": "./dist/node/index.cjs",
       "import": "./dist/es-slim/index_slim.js",
       "default": "./dist/cjs-slim/index_slim.cjs"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-export * from "./index_core";
+export * from "./index_core.js";
 import jomini_wasm from "./pkg/jomini_js_bg.wasm";
-import { setWasmInit } from "./jomini";
+import { setWasmInit } from "./jomini.js";
 
 // @ts-ignore
 setWasmInit(() => jomini_wasm());

--- a/src/index_core.ts
+++ b/src/index_core.ts
@@ -6,5 +6,5 @@ export {
   JominiLoadOptions,
   JsonOptions,
   Writer,
-} from "./jomini";
-export { toArray } from "./toArray";
+} from "./jomini.js";
+export { toArray } from "./toArray.js";

--- a/src/index_slim.ts
+++ b/src/index_slim.ts
@@ -1,1 +1,1 @@
-export * from "./index_core";
+export * from "./index_core.js";

--- a/src/jomini.ts
+++ b/src/jomini.ts
@@ -4,7 +4,7 @@ import init, {
   Query as WasmQuery,
   WasmWriter,
   write_text,
-} from "./pkg/jomini_js";
+} from "./pkg/jomini_js.js";
 
 /**
  * Supported encodings: UTF8 and Windows1252

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,29 +1,16 @@
 {
   "include": ["src", "tests"],
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2022",
     "noEmit": true,
-    // what follows is from the tsdx project
-    "module": "esnext",
-    "lib": ["dom", "esnext"],
-    "importHelpers": true,
-    // output .d.ts declaration files for consumers
+    "module": "ES2022",
+    "lib": ["dom", "ES2022"],
     "declaration": true,
-    // stricter type-checking for stronger correctness. Recommended by TS
+    "declarationDir": "dist/types",
     "strict": true,
-    // linter checks for common issues
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    // noUnused* overlap with @typescript-eslint/no-unused-vars, can disable if duplicative
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    // use Node's module resolution algorithm, instead of the legacy TS one
     "moduleResolution": "node",
-    // interop between ESM and CJS modules. Recommended by TS
     "esModuleInterop": true,
-    // significant perf increase by skipping checking .d.ts files, particularly those in node_modules. Recommended by TS
     "skipLibCheck": true,
-    // error out if import and file system have a casing mismatch. Recommended by TS
     "forceConsistentCasingInFileNames": true
   }
 }


### PR DESCRIPTION
The ES module output now targets ES2022, to allow downstream developers to polyfill what they want.

Imports have been updated to include file extension so that typescript can correctly find types.

Closes #91 