### PR TITLE
Update to rollup-wasm v6.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
       "import": "./dist/es-slim/index_slim.js",
       "default": "./dist/cjs-slim/index_slim.cjs"
     },
-    "./jomini.wasm": "./dist/jomini.wasm",
+    "./jomini.wasm": "./dist/jomini_js_bg.wasm",
     "./package.json": "./package.json"
   },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "wasm-pack build -t web --out-dir ../src/pkg crate && rm -rf dist/ && rollup -c && cp src/pkg/jomini_js_bg.wasm dist/jomini.wasm",
+    "build": "wasm-pack build -t web --out-dir ../src/pkg crate && rm -rf dist/ && rollup -c",
     "build:minify": "npm run build && npx terser@latest --compress --mangle --output dist/cjs/index.cjs -- dist/cjs/index.cjs",
     "format": "npx prettier@latest --write src/ tests/ package.json rollup.config.js tsconfig.json vite.config.ts cli.js",
     "pretest": "npm run build",
@@ -49,7 +49,7 @@
   ],
   "devDependencies": {
     "@rollup/plugin-typescript": "^10.0.1",
-    "@rollup/plugin-wasm": "^6.0.1",
+    "@rollup/plugin-wasm": "^6.1.1",
     "@types/node": "^18.11.10",
     "rollup": "^3.5.1",
     "tslib": "^2.4.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,7 +26,12 @@ const rolls = (fmt, env) => ({
     env != "slim" &&
       wasm(
         env == "node"
-          ? { maxFileSize: 0, targetEnv: "node", publicPath: "../" }
+          ? {
+              maxFileSize: 0,
+              targetEnv: "node",
+              publicPath: "../",
+              fileName: "[name][extname]",
+            }
           : { targetEnv: "auto-inline" }
       ),
     typescript({

--- a/tests/jomini.test.ts
+++ b/tests/jomini.test.ts
@@ -7,6 +7,7 @@ import {
   JominiLoadOptions,
   JsonOptions,
 } from "..";
+import pkg from "../package.json";
 import fs from "fs/promises";
 
 const encoder = new TextEncoder();
@@ -912,7 +913,7 @@ it("should write escaped text", async () => {
 it("should allow custom initialization", async () => {
   let jomini = await Jomini.initialize();
   Jomini.resetModule();
-  const wasm = await fs.readFile("dist/jomini.wasm");
+  const wasm = await fs.readFile(pkg.exports["./jomini.wasm"]);
   const opts: JominiLoadOptions = { wasm };
   jomini = await Jomini.initialize(opts);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "declarationDir": "dist/types",
     "strict": true,
     "moduleResolution": "node",
+    "resolveJsonModule": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
With the new `fileName` config option, we now longer need to copy the wasm to a known location.